### PR TITLE
feat: add requestId parameter

### DIFF
--- a/src/api/routes/transactions.ts
+++ b/src/api/routes/transactions.ts
@@ -184,6 +184,9 @@ export async function getTransaction(
 export type KristApiMakeTransactionOptions = KristAuthOptions & {
   /** Optional metadata to include in the transaction. */
   metadata?: string;
+
+  /** Optional Request ID to use for this transaction. Must be a valid UUIDv4 if provided. */
+  requestId?: string;
 };
 
 /**
@@ -225,6 +228,7 @@ export async function makeTransaction(
     privatekey,
     to,
     amount,
-    metadata: options?.metadata
+    metadata: options?.metadata,
+    requestId: options?.requestId
   })).transaction;
 }

--- a/src/api/ws/routes/wsTransactions.ts
+++ b/src/api/ws/routes/wsTransactions.ts
@@ -24,7 +24,11 @@ import { calculateAddressFromOptions, KristAuthOptions } from "../../../util/int
 import { KristWsClient } from "../KristWsClient.js";
 
 export type KristWsMakeTransactionOptions = KristAuthOptions & {
+  /** Optional metadata to include in the transaction. */
   metadata?: string;
+
+  /** Optional Request ID to use for this transaction. Must be a valid UUIDv4 if provided. */
+  requestId?: string;
 };
 
 /**
@@ -69,6 +73,7 @@ export async function makeTransaction(
     privatekey,
     to,
     amount,
-    metadata: options?.metadata
+    metadata: options?.metadata,
+    requestId: options?.requestId
   })).transaction;
 }

--- a/src/errors/KristError.ts
+++ b/src/errors/KristError.ts
@@ -37,6 +37,8 @@ export class KristErrorAddressNotFound extends KristErrorNotFound {}
 export class KristErrorBlockNotFound extends KristErrorNotFound {}
 export class KristErrorTransactionNotFound extends KristErrorNotFound {}
 export class KristErrorNameNotFound extends KristErrorNotFound {}
+export class KristErrorInsufficientFunds extends KristError {}
+export class KristErrorTransactionConflict extends KristError {}
 export class KristErrorNameTaken extends KristError {}
 export class KristErrorNotNameOwner extends KristError {}
 export class KristErrorInvalidWebSocketToken extends KristError {}
@@ -73,6 +75,10 @@ export function coerceKristError(e: any): KristError | Error {
     return new KristErrorTransactionNotFound(error, message);
   case "name_not_found":
     return new KristErrorNameNotFound(error, message);
+  case "insufficient_funds":
+    return new KristErrorInsufficientFunds(error, message);
+  case "transaction_conflict":
+    return new KristErrorTransactionConflict(error, message);
   case "name_taken":
     return new KristErrorNameTaken(error, message);
   case "not_name_owner":

--- a/src/types/ws.ts
+++ b/src/types/ws.ts
@@ -78,7 +78,7 @@ export const VALID_KRIST_WS_MESSAGE_TYPES = lut(KRIST_WS_MESSAGE_TYPES);
  * @see https://krist.dev/docs/#api-WebsocketGroup
  */
 export type KristWsS2CMessageType = "keepalive" | "hello" | "event"
-  | "response";
+  | "response" | "error";
 
 /**
  * Valid event types that may be received from a websocket connection.
@@ -203,7 +203,7 @@ export interface KristWsS2CResponseMessage extends KristWsS2CMessage {
 }
 /** @internal */
 export const _isMsgResponse = (msg: KristWsS2CMessage):
-  msg is KristWsS2CResponseMessage => msg.type === "response";
+  msg is KristWsS2CResponseMessage => msg.type === "response" || msg.type === "error";
 
 // -----------------------------------------------------------------------------
 // Messages - Addresses
@@ -321,6 +321,7 @@ export interface KristWsC2SMakeTransaction extends KristWsC2SMessage {
   to: string;
   amount: number;
   metadata?: string;
+  requestId?: string;
 }
 
 export interface KristWsS2CMakeTransaction extends KristWsS2CResponseMessage {


### PR DESCRIPTION
Also, I noticed that ws request promises don't reject if they receive an error response since the type is "error" instead of "response", so I fixed that too. Also there was no "insufficient_funds" error class.